### PR TITLE
add ray casting

### DIFF
--- a/src/world.jl
+++ b/src/world.jl
@@ -1,6 +1,7 @@
 mutable struct Agent{T}
     position::SA.SVector{2, T}
     direction::SA.SVector{2, T}
+    camera_plane::SA.SVector{2, T}
 end
 
 struct World{T}

--- a/src/world.jl
+++ b/src/world.jl
@@ -25,3 +25,6 @@ end
 
 rotate(x, y, c, s) = SA.SVector(c * x - s * y, s * x + c * y)
 rotate(vec, dir) = rotate(vec[1], vec[2], dir[1], dir[2])
+rotate_plus_90(vec::SA.SVector{2}) = typeof(vec)(-vec[2], vec[1])
+rotate_minus_90(vec::SA.SVector{2}) = typeof(vec)(vec[2], -vec[1])
+rotate_180(vec::SA.SVector{2}) = -vec

--- a/src/world.jl
+++ b/src/world.jl
@@ -23,5 +23,5 @@ function generate_tile_map(height = 8, width = 8)
     return tile_map
 end
 
-rotate(x::T, y::T, c::T, s::T) where {T} = SA.SVector(c * x - s * y, s * x + c * y)
-rotate(vec, dir) where {T} = rotate(vec[1], vec[2], dir[1], dir[2])
+rotate(x, y, c, s) = SA.SVector(c * x - s * y, s * x + c * y)
+rotate(vec, dir) = rotate(vec[1], vec[2], dir[1], dir[2])

--- a/src/world.jl
+++ b/src/world.jl
@@ -26,6 +26,6 @@ end
 
 rotate(x, y, c, s) = SA.SVector(c * x - s * y, s * x + c * y)
 rotate(vec, dir) = rotate(vec[1], vec[2], dir[1], dir[2])
-rotate_plus_90(vec::SA.SVector{2}) = typeof(vec)(-vec[2], vec[1])
-rotate_minus_90(vec::SA.SVector{2}) = typeof(vec)(vec[2], -vec[1])
-rotate_180(vec::SA.SVector{2}) = -vec
+rotate_plus_90(vec) = typeof(vec)(-vec[2], vec[1])
+rotate_minus_90(vec) = typeof(vec)(vec[2], -vec[1])
+rotate_180(vec) = -vec

--- a/test/run.jl
+++ b/test/run.jl
@@ -14,20 +14,34 @@ const tm = RC.generate_tile_map(height_tm_tu, width_tm_tu)
 
 # agent
 
-const radius_wu = convert(T, 0.05)
-const speed_wu = convert(T, 0.005)
-const theta_change_unit = convert(T, pi / 60)
-const direction_increment = SA.SVector(cos(theta_change_unit), sin(theta_change_unit))
+const theta_30 = convert(T, pi / 6)
+const radius_wu = convert(T, 0.5)
+const position_increment = convert(T, 0.05)
+const theta_increment = convert(T, pi / 60)
+const direction_increment = SA.SVector(cos(theta_increment), sin(theta_increment))
 const direction_decrement = SA.SVector(direction_increment[1], -direction_increment[2])
 
-const agent = RC.Agent(SA.SVector(convert(T, 0.5), convert(T, 0.25)),
-                 SA.SVector(convert(T, 1/sqrt(2)), convert(T, 1/sqrt(2))),
-                )
+agent_position = SA.SVector(convert(T, 4.5), convert(T, 2.5))
+agent_direction = SA.SVector(cos(theta_30), sin(theta_30))
+camera_plane = RC.rotate_minus_90(agent_direction)
+
+const agent = RC.Agent(agent_position,
+                       agent_direction,
+                       camera_plane,
+                      )
+
+# ray
+
+function get_rays()
+    agent_direction = agent.direction
+    camera_plane = agent.camera_plane
+    return map(d -> agent_direction + d * camera_plane, -1:0.5:1)
+end
 
 # world
 
-const height_world_wu = convert(T, 1)
-const width_world_wu = convert(T, 2)
+const height_world_wu = convert(T, 8)
+const width_world_wu = convert(T, 16)
 
 const world = RC.World(tm, height_world_wu, width_world_wu, agent)
 
@@ -90,6 +104,11 @@ get_agent_region_pu() = get_agent_region_pu(get_agent_center_pu())
 
 # main
 
+function clear_screen()
+    img[:, :] .= black
+    return nothing
+end
+
 function draw_tile_map()
     map(get_tile_map_region_tu()) do pos
         if tm[GW.WALL, pos]
@@ -101,12 +120,18 @@ function draw_tile_map()
     return nothing
 end
 
+function draw_tile_map_boundaries()
+    img[1:pu_per_tu:height_img_pu, :] .= gray
+    img[:, 1:pu_per_tu:width_img_pu] .= gray
+    return nothing
+end
+
 function draw_agent()
     center_pu = get_agent_center_pu()
 
     map(get_agent_region_pu(center_pu)) do pos
         if sum((pos.I .- center_pu) .^ 2) <= radius_pu ^ 2
-            img[pos] = gray
+            img[pos] = green
         end
         return nothing
     end
@@ -123,7 +148,7 @@ function draw_line(i0::Int, j0::Int, i1::Int, j1::Int)
     err = di+dj
 
     while true
-        img[i0, j0] = green
+        img[i0, j0] = red
 
         if (i0 == i1 && j0 == j1)
             break
@@ -148,7 +173,7 @@ end
 function draw_agent_direction()
     i0, j0 = get_agent_center_pu()
     i1 = wu_to_pu(height_world_wu - (agent.position[2] + radius_wu * agent.direction[2] / 2))
-    j1 = wu_to_pu(agent.position[1] + radius_wu * agent.direction[1] / 2)
+    j1 = wu_to_pu(agent.position[1] + radius_wu * agent.direction[1] * 3 / 4)
     draw_line(i0, j0, i1, j1)
     return nothing
 end
@@ -163,33 +188,102 @@ function is_agent_colliding(center_wu)
     return tm[GW.WALL, wu_to_tu((x_wu + radius_wu, y_wu))...] || tm[GW.WALL, wu_to_tu((x_wu, y_wu + radius_wu))...] || tm[GW.WALL, wu_to_tu((x_wu - radius_wu, y_wu))...] || tm[GW.WALL, wu_to_tu((x_wu, y_wu - radius_wu))...]
 end
 
+map_to_tu((map_x, map_y)) = (height_tm_tu - map_y, map_x + 1)
+
+cast_rays() = map(ray -> cast_ray(ray), get_rays())
+
+function cast_ray(ray)
+    pos_x, pos_y = agent.position
+    map_x = wu_to_tu(pos_x) - 1
+    map_y = wu_to_tu(pos_y) - 1
+
+    ray_dir = ray
+
+    ray_dir_x, ray_dir_y = ray_dir
+    # delta_dist_x = abs(1 / ray_dir_x)
+    # delta_dist_y = abs(1 / ray_dir_y)
+    ray_dir_norm = sqrt(sum(ray_dir_x ^ 2 + ray_dir_y ^ 2))
+    delta_dist_x = abs(ray_dir_norm / ray_dir_x)
+    delta_dist_y = abs(ray_dir_norm / ray_dir_y)
+
+    if ray_dir_x < zero(ray_dir_x)
+        step_x = -1
+        side_dist_x = (pos_x - map_x) * delta_dist_x
+    else
+        step_x = 1
+        side_dist_x = (map_x + 1 - pos_x) * delta_dist_x
+    end
+
+    if ray_dir_y < zero(ray_dir_y)
+        step_y = -1
+        side_dist_y = (pos_y - map_y) * delta_dist_y
+    else
+        step_y = 1
+        side_dist_y = (map_y + 1 - pos_y) * delta_dist_y
+    end
+
+    hit = 0
+    dist = -1
+
+    while (hit == 0)
+        dist = min(side_dist_x, side_dist_y)
+
+        if (side_dist_x < side_dist_y)
+            side_dist_x += delta_dist_x
+            map_x += step_x
+            side = 0
+        else
+            side_dist_y += delta_dist_y
+            map_y += step_y
+            side = 1
+        end
+
+        if tm[GW.WALL, map_to_tu((map_x, map_y))...]
+            hit = 1
+        end
+    end
+
+    ray_head = agent.position + dist * ray_dir / ray_dir_norm
+    center_pu = get_agent_center_pu()
+    draw_line(center_pu..., wu_to_pu(ray_head)...)
+
+    return nothing
+end
+
 function keyboard_callback(window, key, mod, isPressed)::Cvoid
     if isPressed
         display(key)
         println()
 
-        clear_agent()
+        clear_screen()
 
         if key == MFB.KB_KEY_UP
-            new_position = agent.position + speed_wu * agent.direction
+            new_position = agent.position + position_increment * agent.direction
             if !is_agent_colliding(new_position)
                 agent.position = new_position
             end
         elseif key == MFB.KB_KEY_DOWN
-            new_position = agent.position - speed_wu * agent.direction
+            new_position = agent.position - position_increment * agent.direction
             if !is_agent_colliding(new_position)
                 agent.position = new_position
             end
         elseif key == MFB.KB_KEY_LEFT
-            agent.direction = RC.rotate(agent.direction, direction_increment)
+            new_direction = RC.rotate(agent.direction, direction_increment)
+            agent.direction = new_direction
+            agent.camera_plane = RC.rotate_minus_90(new_direction)
         elseif key == MFB.KB_KEY_RIGHT
-            agent.direction = RC.rotate(agent.direction, direction_decrement)
+            new_direction = RC.rotate(agent.direction, direction_decrement)
+            agent.direction = new_direction
+            agent.camera_plane = RC.rotate_minus_90(new_direction)
         elseif key == MFB.KB_KEY_ESCAPE
             MFB.mfb_close(window)
         end
 
+        draw_tile_map()
+        draw_tile_map_boundaries()
         draw_agent()
         draw_agent_direction()
+        cast_rays()
     end
 
     return nothing
@@ -200,8 +294,10 @@ function render()
     MFB.mfb_set_keyboard_callback(window, keyboard_callback)
 
     draw_tile_map()
+    draw_tile_map_boundaries()
     draw_agent()
     draw_agent_direction()
+    cast_rays()
 
     while MFB.mfb_wait_sync(window)
         state = MFB.mfb_update(window, permutedims!(fb, img, (2, 1)))


### PR DESCRIPTION
1. Add rotation helper methods. Remove type annotations in rotation helper methods.
2. Add tile boundries to image. Set tile width and height equal to 1 world unit each.
3. Add ray casting.