### PR TITLE
fix collision detection

### DIFF
--- a/src/world.jl
+++ b/src/world.jl
@@ -41,3 +41,27 @@ rotate(vec, dir) = rotate(vec[1], vec[2], dir[1], dir[2])
 rotate_plus_90(vec) = typeof(vec)(-vec[2], vec[1])
 rotate_minus_90(vec) = typeof(vec)(vec[2], -vec[1])
 rotate_180(vec) = -vec
+
+struct StdSquare{T}
+    half_side::T
+end
+
+get_half_side(square::StdSquare) = square.half_side
+
+struct StdCircle{T}
+    radius::T
+end
+
+get_radius(circle::StdCircle) = circle.radius
+
+function get_projection(square::StdSquare, pos)
+    half_side = get_half_side(square)
+    return clamp.(pos, -half_side, half_side)
+end
+
+function is_colliding(square::StdSquare, circle::StdCircle, pos)
+    projection = get_projection(square, pos)
+    vec = pos - projection
+    radius = get_radius(circle)
+    return sum(vec .^ 2) < radius * radius
+end

--- a/test/run.jl
+++ b/test/run.jl
@@ -99,14 +99,6 @@ wu_to_tu(x_wu::AbstractFloat) = floor(Int, x_wu * tu_per_wu) + 1
 wu_to_tu((x_wu, y_wu)) = (wu_to_tu(height_world_wu - y_wu), wu_to_tu(x_wu))
 pu_to_tu(i_pu::Integer) = (i_pu - 1) ÷ pu_per_tu + 1
 
-# units
-
-wu_to_pu(x_wu::AbstractFloat) = floor(Int, x_wu * pu_per_wu) + 1
-wu_to_pu((x_wu, y_wu)) = (wu_to_pu(height_world_wu - y_wu), wu_to_pu(x_wu))
-wu_to_tu(x_wu::AbstractFloat) = floor(Int, x_wu * tu_per_wu) + 1
-wu_to_tu((x_wu, y_wu)) = (wu_to_tu(height_world_wu - y_wu), wu_to_tu(x_wu))
-pu_to_tu(i_pu::Integer) = (i_pu - 1) ÷ pu_per_tu + 1
-
 # tile map region
 
 get_tile_map_region_tu() = CartesianIndices((1:height_tm_tu, 1:width_tm_tu))


### PR DESCRIPTION
1. Make tiles be squares in world units.
1. Add structs `StdSquare` and `StdCircle`. Add method `is_colliding` for collision detection between square and circle.
1. Fix `is_agent_colliding` method in `run.jl`.